### PR TITLE
fix: solid playground now runs

### DIFF
--- a/playground/src/renderer/solid.tsx
+++ b/playground/src/renderer/solid.tsx
@@ -1,5 +1,4 @@
 /** @jsxImportSource solid-js */
-/** @jsx "h" */
 /* eslint-disable no-console */
 import { shallowReactive, watch } from 'vue'
 import { createEffect, createSignal } from 'solid-js'

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "ESNext",
     "jsx": "preserve",
-    "jsxImportSource": "solid-js",
     "lib": ["ESNext", "DOM"],
     "module": "ESNext",
     "moduleResolution": "Bundler",

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -4,6 +4,7 @@ import Vue from '@vitejs/plugin-vue'
 import UnoCSS from 'unocss/vite'
 import { svelte as Svelte } from '@sveltejs/vite-plugin-svelte'
 import Solid from 'vite-plugin-solid'
+import React from '@vitejs/plugin-react'
 
 export default defineConfig({
   resolve: {
@@ -16,7 +17,7 @@ export default defineConfig({
     Vue(),
     UnoCSS(),
     Svelte(),
-    Solid({ include: ['*/solid/*.tsx', 'solid.tsx'] }),
-    // React({ exclude: 'solid/solid.tsx' }),
+    Solid({ include: ['src/renderer/solid.tsx', '../src/solid/**'] }),
+    React({ include: ['src/renderer/react.tsx', '../src/react/**'] }),
   ],
 })


### PR DESCRIPTION
This PR fixes the pathfinding for the Solid and React playgrounds. This allows rendering of the playground now