### PR TITLE
fix: solid renderer disposes properly

### DIFF
--- a/playground/src/renderer/solid.tsx
+++ b/playground/src/renderer/solid.tsx
@@ -29,23 +29,22 @@ export const createRendererSolid: RendererFactory = (options): RendererFactoryRe
     return <ShikiMagicMove {...props} class={props.class} />
   }
 
+  let dispose = () => {}
+
   return {
     mount: (element, payload) => {
       Object.assign(props, payload)
-      console.log({ element })
-      render(
+      dispose = render(
         () => <App />,
         element,
       )
-
-      console.log('Solid renderer mounted')
     },
 
     update: (payload) => {
       Object.assign(props, payload)
     },
     dispose: () => {
-      console.log('Solid renderer disposed')
+      dispose?.()
     },
   }
 }


### PR DESCRIPTION
Previously, if you selected the Solid renderer and then any other renderer, it would not cleanup the Solid renderer:

<img width="697" alt="Screenshot 2024-10-01 at 11 33 07 PM" src="https://github.com/user-attachments/assets/c21501b3-c257-4f7a-8617-3ff74303540c">

This PR fixes this